### PR TITLE
Telemetry exportation fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,8 +121,8 @@ fn main() {
     println!("\n┌─────────────────────────┐");
     println!("│     FLIGHT SUMMARY      │");
     println!("├─────────────────────────┤");
-    println!("│ Duration: {:>6.1}s      │", simulator.time);
-    println!("│ Max Alt:  {:>6.1}m      │", max_altitude);
+    println!("│ Duration: {:>6.1}s       │", simulator.time);
+    println!("│ Max Alt:  {:>6.1}m       │", max_altitude);
     println!("│ Outcome:  {:>11}   │", outcome);
     println!("└─────────────────────────┘");
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,7 @@ fn main() {
     println!("└─────────────────────────┘");
     
     // Export telemetry
+    println!("Exporting telemetry...");
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_else(|_| std::time::Duration::from_secs(0))


### PR DESCRIPTION
## Fixing issue when exporting the telemetry data. This solves issue #10 

Here we get the current path of the exe cause it also happen that if you execute the program from another folder it tries to export it there e.g. ("../../eclipse.exe")
```rust
let current_path  = std::env::current_exe()?.display().to_string().replace("\\", "/").replace("eclipse.exe", "");
```

Here we're just grabing the folder that it wants to save the file from the file name splitting it with "/"
[0] = flights, [1] = mode_selected
Output: Path = current_path/{flights}/{mode_selected}
```rust
let path = format!("{}{}/{}", current_path,filename.split("/").collect::<Vec<&str>>()[0], filename.split("/").collect::<Vec<&str>>()[1]); 
```
We check if that path exists and if not then it gonna create it
```rust
let does_exists = exists(&path); //Checks if dir exists

        if !does_exists?{ // True if it exists and false if it doesn't, "?" to grab the bool value of the Result type
            let now_exists = create_dir_all(&path);
```
---
### Extra:
For some reason the padding wasn't right
```rust
    println!("│ Duration: {:>6.1}s       │", simulator.time);
    println!("│ Max Alt:  {:>6.1}m       │", max_altitude);
```

And just some status message so user know what is doing
```rust
println!("Exporting telemetry...");
```